### PR TITLE
fix: Add multi-platform Docker build support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Build and Push Multi-Platform Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., 2.3.0)'
+        required: true
+        type: string
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: tmfrisinger/webcat
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}
+
+      - name: Verify multi-platform manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,16 +4,42 @@ set -e
 # Configuration
 IMAGE_NAME="webcat"
 USER="tmfrisinger"
-VERSION=2.2.2
+VERSION=2.3.0
 TAG="${USER}/${IMAGE_NAME}:${VERSION}"
 LATEST="${USER}/${IMAGE_NAME}:latest"
 DEFAULT_PORT=8000
+PLATFORMS="linux/amd64,linux/arm64"
 
 # Navigate to the root directory
 cd "$(dirname "$0")/.."
 
 echo "Building Docker image for FastMCP WebCAT: ${TAG}"
-docker build -t ${TAG} -t ${LATEST} -f docker/Dockerfile .
+echo "Platforms: ${PLATFORMS}"
+
+# Check if buildx is available
+if ! docker buildx version &> /dev/null; then
+    echo "Error: docker buildx is not available. Please install it first."
+    exit 1
+fi
+
+# Create a new builder instance if it doesn't exist
+if ! docker buildx ls | grep -q "multiarch"; then
+    echo "Creating multiarch builder..."
+    docker buildx create --name multiarch --use
+fi
+
+# Use the multiarch builder
+docker buildx use multiarch
+
+# Build multi-platform image
+echo "Building multi-platform image..."
+docker buildx build \
+    --platform ${PLATFORMS} \
+    -t ${TAG} \
+    -t ${LATEST} \
+    -f docker/Dockerfile \
+    --load \
+    .
 
 echo "Docker image built successfully!"
 echo "To run the Docker image locally:"
@@ -26,10 +52,6 @@ echo "To customize logging:"
 echo "docker run -p ${DEFAULT_PORT}:${DEFAULT_PORT} -e SERPER_API_KEY=your_key -e LOG_LEVEL=DEBUG ${LATEST}"
 echo ""
 echo "To push to a registry, run:"
-echo "docker push ${TAG}"
-echo "docker push ${LATEST}"
-
-# Uncomment the following lines if you want to automatically push to a registry
-# docker push ${TAG}
-# docker push ${LATEST}
-# echo "Docker image pushed successfully!"
+echo "docker buildx build --platform ${PLATFORMS} -t ${TAG} -t ${LATEST} -f docker/Dockerfile --push ."
+echo ""
+echo "Note: Use --push flag with buildx to push multi-platform images to registry"


### PR DESCRIPTION
## Summary
- Fixes "no matching manifest for linux/amd64" error when pulling Docker images
- Adds multi-platform build support for linux/amd64 and linux/arm64
- Creates automated GitHub Actions workflow for multi-platform builds

## Changes
- **docker/build.sh**: Updated to version 2.3.0 with Docker buildx for multi-platform builds
- **.github/workflows/docker-publish.yml**: New workflow for automated multi-platform Docker builds

## Technical Details
- Uses Docker buildx with QEMU for cross-platform compilation
- Supports both Intel/AMD x86_64 and ARM64 (Apple Silicon) platforms
- Workflow triggers on version tags (v*.*.*) or manual dispatch
- Includes build caching for improved performance

## Testing
- Successfully built and pushed `tmfrisinger/webcat:2.3.0` with multi-platform support
- Verified both linux/amd64 and linux/arm64 manifests are available
- Images now pull correctly on all supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-platform Docker images (linux/amd64 and linux/arm64) are now built and published.
  - Versioned and latest tags are generated for releases (e.g., vX.Y.Z).
  - Manual release support via workflow input for versioned builds.
  - Version bumped to 2.3.0.

- Chores
  - Automated CI workflow added to build, tag, and push Docker images to the registry, including metadata generation and multi-arch manifest verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->