### PR TITLE
fix: Load .env before importing tools

### DIFF
--- a/docker/mcp_server.py
+++ b/docker/mcp_server.py
@@ -44,16 +44,17 @@ import os
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 
-from tools.health_check_tool import health_check_tool
-from tools.search_tool import search_tool
 from utils.logging_config import setup_logging
+
+# Load environment variables FIRST before importing tools
+load_dotenv()
 
 # Set up logging
 logger = setup_logging("webcat.log")
 
-# Load environment variables
-load_dotenv()
-
+# Import tools AFTER loading .env so they can access environment variables
+from tools.health_check_tool import health_check_tool  # noqa: E402
+from tools.search_tool import search_tool  # noqa: E402
 
 # Log configuration status
 SERPER_API_KEY = os.environ.get("SERPER_API_KEY", "")


### PR DESCRIPTION
## Summary
Fixes an issue where tools couldn't access environment variables from `.env` file because `load_dotenv()` ran after tool imports.

## Changes
- Move `load_dotenv()` to run **before** importing tool modules in `mcp_server.py`
- Ensures `SERPER_API_KEY` and other environment variables are set before tools initialize
- Add `noqa: E402` comments for intentional late imports (required for proper initialization order)

## Why This Matters
Previously, tool modules like `search_tool.py` would try to read `os.environ.get("SERPER_API_KEY")` at import time, but `.env` hadn't been loaded yet, so the key was empty.

Now the initialization order is:
1. Load `.env` file
2. Set up logging
3. Import tools (which can now access env vars)

## Test Plan
- ✅ Tested with real Serper API call
- ✅ Confirmed env variables load before tool import
- ✅ Search tool successfully uses SERPER_API_KEY from .env
- ✅ Real API test returns expected results with max_results parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves server startup reliability by loading environment settings before initializing tools, preventing missing-configuration errors at launch.
  * Ensures consistent behavior across environments that rely on .env files, reducing intermittent initialization issues.
  * No user action required; existing features and interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->